### PR TITLE
Shorten documentation link name to "Docs"

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                         <span class="link-separator"></span>
                         <a href="https://discord.com/invite/4njFDtfGEZ" title="Discord">Discord</a>
                         <span class="link-separator"></span>
-                        <a href="http://gradience.rtfd.io/" title="Documentation">Documentation</a>
+                        <a href="https://gradience.rtfd.io" title="Docs">Docs</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
As the title says, this commit shortens documentation link name from full `Documentation` to `Docs`.

@0xMRTT could you add me to Web team if it has edit perms for this repo? Also, `gradience.atrophaneura.tech` URL no longer works.